### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,9 +1,9 @@
 Authors
 -------
 
-setuptools-bower is developed for use in `Invenio <http://invenio-software.org>`_ digital library software.
+setuptools-bower is developed for use in `Invenio <http://inveniosoftware.org>`_ digital library software.
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 Contributors
 ^^^^^^^^^^^^

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -35,8 +35,8 @@ Homepage
 Good luck and thanks for choosing setuptools-bower.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: http://github.com/inveniosoftware
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,7 +99,7 @@ the interested.
 Contributing
 ------------
 
-See <http://invenio-software.org/wiki/Development/Contributing> for now.
+See <http://inveniosoftware.org/wiki/Development/Contributing> for now.
 
 
 .. include:: ../CHANGES

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url='http://github.com/inveniosoftware/setuptools-bower/',
     license='BSD',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description='Setuptools commands for integrating bower.',
     long_description=open('README.rst').read(),
     packages=['setuptools_bower', ],


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>